### PR TITLE
Lock non-docker to v1, just like for Docker

### DIFF
--- a/callgraph-non-docker/action.yml
+++ b/callgraph-non-docker/action.yml
@@ -5,8 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Debricked CLI
-      run: curl -L https://github.com/debricked/cli/releases/latest/download/cli_linux_x86_64.tar.gz | tar -xz debricked
-      shell: bash
+      uses: debricked/actions/non-docker@v3
     - name: Debricked Resolve
       run: ./debricked callgraph
       shell: bash

--- a/non-docker/action.yaml
+++ b/non-docker/action.yaml
@@ -1,0 +1,19 @@
+name: Debricked CLI installation
+author: Debricked
+description: Installs the Debricked CLI
+runs:
+  using: composite
+  steps:
+    - name: Install Debricked CLI
+      run: |
+        # Convert GitHub's RUNNER_ARCH naming convention to match the ones we use for releases
+        if [ "${RUNNER_ARCH}" == "X64" ]; then RUNNER_ARCH=x86_64; fi
+        if [ "${RUNNER_ARCH}" == "X86" ]; then RUNNER_ARCH=i386; fi
+        BIN_NAME=debricked
+        if [ "${RUNNER_OS}" == "Windows" ]; then BIN_NAME=debricked.exe; fi
+        echo "https://github.com/debricked/cli/releases/download/release-v1/cli_${RUNNER_OS}_${RUNNER_ARCH}.tar.gz"
+        curl -L "https://github.com/debricked/cli/releases/download/release-v1/cli_${RUNNER_OS}_${RUNNER_ARCH}.tar.gz" | tar -xz "${BIN_NAME}"
+      shell: bash
+branding:
+  color: purple
+  icon: search

--- a/resolve-non-docker/action.yml
+++ b/resolve-non-docker/action.yml
@@ -5,8 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Debricked CLI
-      run: curl -L https://github.com/debricked/cli/releases/latest/download/cli_linux_x86_64.tar.gz | tar -xz debricked
-      shell: bash
+      uses: debricked/actions/non-docker@v3
     - name: Debricked Resolve
       run: ./debricked resolve
       shell: bash

--- a/scan-non-docker/action.yml
+++ b/scan-non-docker/action.yml
@@ -5,8 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Debricked CLI
-      run: curl -L https://github.com/debricked/cli/releases/latest/download/cli_linux_x86_64.tar.gz | tar -xz debricked
-      shell: bash
+      uses: debricked/actions/non-docker@v3
     - name: Debricked Scan
       run: ./debricked scan
       shell: bash


### PR DESCRIPTION
Support running non-docker on non-linux x64 runners